### PR TITLE
feat: add origin URLs to SDF -> WoT conversion

### DIFF
--- a/sdf_wot_converter/__init__.py
+++ b/sdf_wot_converter/__init__.py
@@ -368,7 +368,7 @@ def _parse_arguments(args):
 def get_origin_url(path: str, url: str):
     if url:
         return url
-    elif path.startswith("http://") or path.startswith("https://"):
+    elif path and (path.startswith("http://") or path.startswith("https://")):
         return path
     else:
         return None

--- a/sdf_wot_converter/__init__.py
+++ b/sdf_wot_converter/__init__.py
@@ -113,9 +113,9 @@ def _convert_model_from_json(
     return json.dumps(to_model, indent=indent)
 
 
-def convert_sdf_to_wot_tm(input: Dict):
+def convert_sdf_to_wot_tm(input: Dict, origin_url=None):
     return _convert_and_validate(
-        input, sdf_validation_schema, tm_schema, sdf_to_wot.convert_sdf_to_wot_tm
+        input, sdf_validation_schema, tm_schema, sdf_to_wot.convert_sdf_to_wot_tm, origin_url=origin_url
     )
 
 
@@ -147,7 +147,7 @@ def convert_wot_td_to_tm(input: Dict):
     return _convert_and_validate(input, td_schema, tm_schema, td_to_tm.convert_td_to_tm)
 
 
-def convert_sdf_to_wot_tm_from_path(from_path: str, to_path: str, indent=4):
+def convert_sdf_to_wot_tm_from_path(from_path: str, to_path: str, indent=4, **kwargs):
     return _convert_model_from_path(
         from_path,
         to_path,
@@ -155,6 +155,7 @@ def convert_sdf_to_wot_tm_from_path(from_path: str, to_path: str, indent=4):
         tm_schema,
         sdf_to_wot.convert_sdf_to_wot_tm,
         indent=indent,
+        **kwargs
     )
 
 
@@ -350,6 +351,10 @@ def _parse_arguments(args):
     )
 
     parser.add_argument(
+        "--origin-url", dest="origin_url", help="Explicitly set the model's origin URL."
+    )
+
+    parser.add_argument(
         "--indent",
         dest="indent",
         default=4,
@@ -360,11 +365,23 @@ def _parse_arguments(args):
     return parser.parse_args(args)
 
 
+def get_origin_url(path: str, url: str):
+    if url:
+        return url
+    elif path.startswith("http://") or path.startswith("https://"):
+        return path
+    else:
+        return None
+
+
 def _use_converter_cli(args):  # pragma: no cover
     indent = args.indent
     if args.from_sdf:
+        origin_url = get_origin_url(args.from_sdf, args.origin_url)
         if args.to_tm:
-            convert_sdf_to_wot_tm_from_path(args.from_sdf, args.to_tm, indent=indent)
+            convert_sdf_to_wot_tm_from_path(
+                args.from_sdf, args.to_tm, indent=indent, origin_url=origin_url
+            )
         elif args.to_sdf:
             _load_and_save_model(args.from_sdf, args.to_sdf, indent=indent)
         elif args.to_td:
@@ -377,6 +394,7 @@ def _use_converter_cli(args):  # pragma: no cover
                     args.to_sdf,
                     placeholder_map_path=args.placeholder_map,
                     indent=indent,
+                    origin_url=args.origin_url,
                 )
             else:
                 convert_wot_tm_to_sdf_from_paths(

--- a/sdf_wot_converter/__init__.py
+++ b/sdf_wot_converter/__init__.py
@@ -115,7 +115,11 @@ def _convert_model_from_json(
 
 def convert_sdf_to_wot_tm(input: Dict, origin_url=None):
     return _convert_and_validate(
-        input, sdf_validation_schema, tm_schema, sdf_to_wot.convert_sdf_to_wot_tm, origin_url=origin_url
+        input,
+        sdf_validation_schema,
+        tm_schema,
+        sdf_to_wot.convert_sdf_to_wot_tm,
+        origin_url=origin_url,
     )
 
 
@@ -155,7 +159,7 @@ def convert_sdf_to_wot_tm_from_path(from_path: str, to_path: str, indent=4, **kw
         tm_schema,
         sdf_to_wot.convert_sdf_to_wot_tm,
         indent=indent,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/sdf_wot_converter/converters/sdf_to_wot.py
+++ b/sdf_wot_converter/converters/sdf_to_wot.py
@@ -598,7 +598,7 @@ def add_origin_link(thing_model: Dict, origin_url: str):
         if "links" in thing_model:
             thing_model["links"].append(origin_link)
         else:
-            thing_model["links"] = origin_link
+            thing_model["links"] = [origin_link]
 
 
 def convert_sdf_to_wot_tm(sdf_model: Dict, origin_url=None) -> Dict:

--- a/sdf_wot_converter/converters/sdf_to_wot.py
+++ b/sdf_wot_converter/converters/sdf_to_wot.py
@@ -589,7 +589,19 @@ def map_sdf_ref(thing_model: Dict, current_definition: Dict):
             map_sdf_ref(thing_model, value)
 
 
-def convert_sdf_to_wot_tm(sdf_model: Dict) -> Dict:
+def add_origin_link(thing_model: Dict, origin_url: str):
+    if origin_url:
+        origin_link = {
+            "href": origin_url,
+            "rel": "alternate",  # TODO: Which kind of link relation should be used?
+        }
+        if "links" in thing_model:
+            thing_model["links"].append(origin_link)
+        else:
+            thing_model["links"] = origin_link
+
+
+def convert_sdf_to_wot_tm(sdf_model: Dict, origin_url=None) -> Dict:
 
     thing_model: Dict = {
         "@context": ["http://www.w3.org/ns/td"],
@@ -613,5 +625,7 @@ def convert_sdf_to_wot_tm(sdf_model: Dict) -> Dict:
     map_sdf_required(thing_model)
     map_sdf_ref(thing_model, thing_model)
     del thing_model["mappings"]
+
+    add_origin_link(thing_model, origin_url)
 
     return thing_model

--- a/tests/converter/test_cli.py
+++ b/tests/converter/test_cli.py
@@ -274,5 +274,5 @@ def test_get_origin_url():
     assert get_origin_url("http://example.com", None) == "http://example.com"
     assert get_origin_url("https://example.com", None) == "https://example.com"
     assert get_origin_url(None, "http://example.com") == "http://example.com"
-    assert get_origin_url("http://example.com", "http://example.org") == "http://example.org"
+    assert get_origin_url("http://hi.com", "http://example.com") == "http://example.com"
     assert get_origin_url("this/is/a/file/path", None) == None

--- a/tests/converter/test_cli.py
+++ b/tests/converter/test_cli.py
@@ -12,6 +12,7 @@ from sdf_wot_converter import (
     convert_wot_tm_to_sdf_from_json,
     convert_wot_tm_to_wot_td_from_json,
     convert_wot_td_to_wot_tm_from_json,
+    get_origin_url,
 )
 import os
 
@@ -266,3 +267,12 @@ def test_wot_td_tm_json_conversion():
     result = json.loads(convert_wot_td_to_wot_tm_from_json(json.dumps(input)))
 
     assert result == expected_result
+
+
+def test_get_origin_url():
+    assert get_origin_url(None, None) == None
+    assert get_origin_url("http://example.com", None) == "http://example.com"
+    assert get_origin_url("https://example.com", None) == "https://example.com"
+    assert get_origin_url(None, "http://example.com") == "http://example.com"
+    assert get_origin_url("http://example.com", "http://example.org") == "http://example.org"
+    assert get_origin_url("this/is/a/file/path", None) == None

--- a/tests/converter/test_sdf_to_wot.py
+++ b/tests/converter/test_sdf_to_wot.py
@@ -4,6 +4,8 @@ from sdf_wot_converter import (
 )
 import pytest
 
+from sdf_wot_converter.converters.sdf_to_wot import add_origin_link
+
 
 def perform_sdf_roundtrip_test(input):
     converted_model = convert_sdf_to_wot_tm(input)
@@ -610,3 +612,16 @@ def test_empty_namespace_conversion():
 
     perform_conversion_test(input, expected_result)
     perform_sdf_roundtrip_test(input)
+
+
+def test_add_origin_link():
+    input1 = {}
+    input2 = {"links": []}
+
+    expected_result1 = {"links": [{"href": "https://example.org", "rel": "alternate"}]}
+
+    add_origin_link(input1, origin_url="https://example.org")
+    add_origin_link(input2, origin_url="https://example.org")
+    print(input1)
+    assert input1 == expected_result1
+    assert input2 == expected_result1


### PR DESCRIPTION
This PR adds the inclusion of the URL an SDF model originated from as a feature to the converter. If the SDF model has been downloaded from a URL, this one is used in the resulting Thing Model. However, it also possible to specify the origin URL manually using an `--origin-url` parameter.