### PR TITLE
feat: rework converter

### DIFF
--- a/.github/workflows/build_status.yml
+++ b/.github/workflows/build_status.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-cov jsonschema jsonpointer json-merge-patch
+        pip install flake8 pytest pytest-cov jsonschema jsonpointer json-merge-patch validators
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/convert_sdf_models.yml
+++ b/.github/workflows/convert_sdf_models.yml
@@ -22,7 +22,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install -q build
         python -m build
-        pip install --find-links dist/ sdf-wot-converter
+        pip install jsonschema jsonpointer json-merge-patch validators
+        pip install --no-index --find-links dist/ sdf-wot-converter
     - name: Convert SDF models to WoT TM
       run: ./convert_playground.sh
     - name: Export conversion results

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ cython_debug/
 
 # Ignore test output
 test_output
+
+# Ignore vscode settings
+.vscode

--- a/sdf_wot_converter/converters/td_to_tm.py
+++ b/sdf_wot_converter/converters/td_to_tm.py
@@ -1,6 +1,8 @@
 from typing import Dict
 import copy
 
+from .utility import validate_thing_description, validate_thing_model
+
 
 def _replace_type(thing_model: Dict):
 
@@ -25,8 +27,10 @@ def _replace_type(thing_model: Dict):
 
 
 def convert_td_to_tm(thing_description: Dict) -> Dict:
+    validate_thing_description(thing_description)
     thing_model: Dict = copy.deepcopy(thing_description)
 
     _replace_type(thing_model)
+    validate_thing_model(thing_model)
 
     return thing_model

--- a/sdf_wot_converter/converters/tm_to_td.py
+++ b/sdf_wot_converter/converters/tm_to_td.py
@@ -4,6 +4,8 @@ from typing import (
 import copy
 import json_merge_patch
 from jsonpointer import resolve_pointer
+
+from .utility import validate_thing_description, validate_thing_model
 from . import wot_common
 
 
@@ -45,6 +47,7 @@ def _replace_bindings(partial_td, bindings) -> Dict:
 def convert_tm_to_td(
     thing_model: Dict, placeholder_map=None, meta_data=None, bindings=None
 ) -> Dict:
+    validate_thing_model(thing_model)
     partial_td: Dict = copy.deepcopy(thing_model)
 
     partial_td = wot_common.resolve_extension(partial_td)
@@ -56,5 +59,7 @@ def convert_tm_to_td(
     partial_td = wot_common.replace_placeholders(partial_td, placeholder_map)
 
     assert_tm_required(partial_td)
+
+    validate_thing_description(partial_td)
 
     return partial_td

--- a/sdf_wot_converter/converters/utility.py
+++ b/sdf_wot_converter/converters/utility.py
@@ -1,4 +1,8 @@
 from typing import Dict
+from ..schemas.sdf_validation_schema import sdf_validation_schema
+from ..schemas.td_schema import td_schema
+from ..schemas.tm_schema import tm_schema
+from jsonschema import Draft7Validator
 
 
 def initialize_object_field(model: Dict, field_name: str):
@@ -9,3 +13,15 @@ def initialize_object_field(model: Dict, field_name: str):
 def initialize_list_field(model: Dict, field_name: str):
     if field_name not in model:
         model[field_name] = []
+
+
+def validate_sdf_model(sdf_model: Dict):
+    Draft7Validator(sdf_validation_schema).validate(sdf_model)
+
+
+def validate_thing_model(thing_model: Dict):
+    Draft7Validator(tm_schema).validate(thing_model)
+
+
+def validate_thing_description(thing_description: Dict):
+    Draft7Validator(td_schema).validate(thing_description)

--- a/sdf_wot_converter/converters/wot_to_sdf.py
+++ b/sdf_wot_converter/converters/wot_to_sdf.py
@@ -1,102 +1,112 @@
+import os
 from typing import (
     Any,
     Dict,
+    Set,
+    Union,
 )
+import warnings
+
+import jsonschema
 from .utility import (
-    initialize_list_field,
     initialize_object_field,
+    validate_sdf_model,
 )
-from jsonpointer import resolve_pointer, set_pointer
 from . import wot_common
+import urllib.parse
 
 
-def initialize_object_from_json_pointer(sdf_model: Dict, json_pointer: str):
-    current_element = sdf_model
-    for element in json_pointer.split("/"):
-        if not element or element == "#":
-            continue  # pragma: no cover
-        initialize_object_field(current_element, element)
-        current_element = current_element[element]
-
-
-def determine_json_pointer(sdf_model, base_field_name, key, property):
-    json_pointer = f"/{base_field_name}/{key}"
-    if "sdf:jsonPointer" in property:
-        json_pointer = property["sdf:jsonPointer"][1:]
-    initialize_object_from_json_pointer(sdf_model, json_pointer)
-    return json_pointer
-
-
-def map_properties(thing_model: Dict, sdf_model: Dict):
+def map_properties(
+    thing_model: Dict, sdf_model: Dict, sdf_mapping_file, current_path: str
+):
     for key, wot_property in thing_model.get("properties", {}).items():
-        json_pointer = determine_json_pointer(
-            sdf_model, "sdfProperty", key, wot_property
-        )
+        if "sdfProperty" not in sdf_model:
+            sdf_model["sdfProperty"] = {}
         sdf_property: Dict[str, Any] = {}
         map_interaction_affordance_fields(wot_property, sdf_property)
-        map_data_schema_fields(thing_model, wot_property, sdf_property)
+        map_data_schema_fields(thing_model, wot_property, sdf_property, current_path)
 
-        set_pointer(sdf_model, json_pointer, sdf_property)
+        sdf_model["sdfProperty"][key] = sdf_property
 
 
-def map_items(thing_model, wot_definition: Dict, sdf_definition: Dict):
+def map_items(
+    thing_model, wot_definition: Dict, sdf_definition: Dict, current_path: str
+):
     if "items" in wot_definition:
         sdf_definition["items"] = {}
         map_data_schema_fields(
-            thing_model, wot_definition["items"], sdf_definition["items"]
+            thing_model, wot_definition["items"], sdf_definition["items"], current_path
         )
 
 
-def map_dataschema_properties(thing_model, wot_definition: Dict, sdf_definition: Dict):
+def map_dataschema_properties(
+    thing_model, wot_definition: Dict, sdf_definition: Dict, current_path: str
+):
     for key, property in wot_definition.get("properties", {}).items():
         initialize_object_field(sdf_definition, "properties")
         sdf_definition["properties"][key] = {}
-        map_data_schema_fields(thing_model, property, sdf_definition["properties"][key])
+        map_data_schema_fields(
+            thing_model, property, sdf_definition["properties"][key], current_path
+        )
 
 
-def map_actions(thing_model: Dict, sdf_model: Dict):
+def map_actions(
+    thing_model: Dict, sdf_model: Dict, sdf_mapping_file, current_path: str
+):
     for key, wot_action in thing_model.get("actions", {}).items():
-        json_pointer = determine_json_pointer(sdf_model, "sdfAction", key, wot_action)
+        affordance_path = f"{current_path}/sdfAction/{key}"
+        if "sdfAction" not in sdf_model:
+            sdf_model["sdfAction"] = {}
         sdf_action: Dict[str, Any] = {}
         map_sdf_comment(wot_action, sdf_action)
         map_interaction_affordance_fields(wot_action, sdf_action)
-        map_action_fields(thing_model, wot_action, sdf_action)
-        set_pointer(sdf_model, json_pointer, sdf_action)
-        map_tm_ref(thing_model, wot_action, sdf_action)
+        map_action_fields(thing_model, wot_action, sdf_action, current_path)
+        map_tm_ref(thing_model, wot_action, sdf_action, current_path)
+        sdf_model["sdfAction"][key] = sdf_action
 
 
-def map_action_fields(thing_model, wot_action, sdf_action):
+def map_action_fields(thing_model, wot_action, sdf_action, current_path: str):
     # TODO: Missing fields: safe, idempotent
     if "input" in wot_action:
-        sdf_input_data = {}
-        map_data_schema_fields(thing_model, wot_action["input"], sdf_input_data)
+        sdf_input_data: Dict[str, Any] = {}
+        map_data_schema_fields(
+            thing_model, wot_action["input"], sdf_input_data, current_path
+        )
         sdf_action["sdfInputData"] = sdf_input_data
     if "output" in wot_action:
-        sdf_output_data = {}
-        map_data_schema_fields(thing_model, wot_action["output"], sdf_output_data)
+        sdf_output_data: Dict[str, Any] = {}
+        map_data_schema_fields(
+            thing_model, wot_action["output"], sdf_output_data, current_path
+        )
         sdf_action["sdfOutputData"] = sdf_output_data
 
 
-def map_events(thing_model: Dict, sdf_model: Dict):
+def map_events(thing_model: Dict, sdf_model: Dict, sdf_mapping_file, current_path: str):
     for key, wot_event in thing_model.get("events", {}).items():
-        json_pointer = determine_json_pointer(sdf_model, "sdfEvent", key, wot_event)
+        if "sdfEvent" not in sdf_model:
+            sdf_model["sdfEvent"] = {}
+
         sdf_event: Dict[str, Any] = {}
         map_sdf_comment(wot_event, sdf_event)
         map_interaction_affordance_fields(wot_event, sdf_event)
-        map_event_fields(thing_model, wot_event, sdf_event)
-        set_pointer(sdf_model, json_pointer, sdf_event)
-        map_tm_ref(thing_model, wot_event, sdf_event)
+        map_event_fields(thing_model, wot_event, sdf_event, current_path)
+        map_tm_ref(thing_model, wot_event, sdf_event, current_path)
+        sdf_model["sdfEvent"][key] = sdf_event
 
 
-def map_event_fields(thing_model, wot_event, sdf_event):
+def map_event_fields(thing_model, wot_event, sdf_event, current_path: str):
     # TODO: Missing fields: subscription, cancellation
     if "data" in wot_event:
-        sdf_input_data = {}
-        map_data_schema_fields(thing_model, wot_event["data"], sdf_input_data)
+        sdf_input_data: Dict = {}
+        map_data_schema_fields(
+            thing_model, wot_event["data"], sdf_input_data, current_path
+        )
         sdf_event["sdfOutputData"] = sdf_input_data
 
 
-def map_data_schema_fields(thing_model, wot_definition: Dict, sdf_definition: Dict):
+def map_data_schema_fields(
+    thing_model, wot_definition: Dict, sdf_definition: Dict, current_path: str
+):
     # TODO: Unmapped fields: @type, titles, descriptions, oneOf,
     # TODO: Deal with sdfType and nullable
     map_sdf_comment(wot_definition, sdf_definition)
@@ -127,10 +137,10 @@ def map_data_schema_fields(thing_model, wot_definition: Dict, sdf_definition: Di
     map_exclusive_maximum(wot_definition, sdf_definition)
     map_content_format(wot_definition, sdf_definition)
 
-    map_items(thing_model, wot_definition, sdf_definition)
-    map_dataschema_properties(thing_model, wot_definition, sdf_definition)
+    map_items(thing_model, wot_definition, sdf_definition, current_path)
+    map_dataschema_properties(thing_model, wot_definition, sdf_definition, current_path)
 
-    map_tm_ref(thing_model, wot_definition, sdf_definition)
+    map_tm_ref(thing_model, wot_definition, sdf_definition, current_path)
 
 
 def map_const(wot_definition: Dict, sdf_definition: Dict):
@@ -214,9 +224,18 @@ def map_unit(wot_definition: Dict, sdf_definition: Dict):
 
 
 def map_enum(wot_definition: Dict, sdf_definition: Dict):
-    # TODO: Map enum to sdfChoice
     if "enum" in wot_definition:
-        sdf_definition["enum"] = wot_definition["enum"]
+        for enum in wot_definition["enum"]:
+            if type(enum) is dict and "sdf:choiceName" in enum:
+                if sdf_definition.get("sdfChoice") is None:
+                    sdf_definition["sdfChoice"] = {}
+                choice_name = enum["sdf:choiceName"]
+                sdf_definition["sdfChoice"][choice_name] = enum
+                del sdf_definition["sdfChoice"][choice_name]["sdf:choiceName"]
+            else:
+                if sdf_definition.get("enum") is None:
+                    sdf_definition["enum"] = []
+                sdf_definition["enum"].append(enum)
 
 
 def map_read_only(wot_definition: Dict, sdf_definition: Dict):
@@ -263,60 +282,49 @@ def map_description(wot_definition: Dict, sdf_definition: Dict):
         sdf_definition["description"] = wot_definition["description"]
 
 
-def map_schema_definitions(thing_model: Dict, sdf_model: Dict):
+def map_schema_definitions(
+    thing_model: Dict, sdf_model: Dict, sdf_mapping_file, current_path: str
+):
     for key, wot_schema_definitions in thing_model.get("schemaDefinitions", {}).items():
-        json_pointer = determine_json_pointer(
-            sdf_model, "sdfData", key, wot_schema_definitions
-        )
+        if "sdfData" not in sdf_model:
+            sdf_model["sdfData"] = {}
         sdf_data: Dict[str, Any] = {}
         map_sdf_comment(wot_schema_definitions, sdf_data)
-        map_data_schema_fields(thing_model, wot_schema_definitions, sdf_data)
-        map_tm_ref(thing_model, wot_schema_definitions, sdf_data)
+        map_data_schema_fields(
+            thing_model, wot_schema_definitions, sdf_data, current_path
+        )
+        map_tm_ref(thing_model, wot_schema_definitions, sdf_data, current_path)
 
-        set_pointer(sdf_model, json_pointer, sdf_data)
-
-
-def initialize_empty_string_field(sdf_definition: Dict, field_name: str):
-    if field_name not in sdf_definition:
-        sdf_definition[field_name] = ""
-
-
-def initialize_info_block(sdf_model: Dict):
-    initialize_object_field(sdf_model, "info")
-    infoblock = sdf_model["info"]
-
-    for field in ["title", "copyright", "version", "license"]:
-        initialize_empty_string_field(infoblock, field)
+        sdf_model["sdfData"][key] = sdf_data
 
 
 def map_thing_title(wot_definition: Dict, sdf_definition: Dict):
     if "title" in wot_definition:
-        initialize_info_block(sdf_definition)
-        sdf_definition["info"]["title"] = wot_definition["title"]
+        sdf_definition["label"] = wot_definition["title"]
 
 
 def map_thing_description(wot_definition: Dict, sdf_definition: Dict):
     if "description" in wot_definition:
-        initialize_info_block(sdf_definition)
-        sdf_definition["info"]["copyright"] = wot_definition["description"]
+        sdf_definition["description"] = wot_definition["description"]
 
 
-def map_links(wot_definition: Dict, sdf_definition: Dict):
+def map_links(wot_definition: Dict, sdf_definition: Dict, sdf_mapping_file):
     # TODO: Deal with other link types
     for link in wot_definition.get("links", []):
         if link.get("rel") == "license":
-            initialize_info_block(sdf_definition)
-            sdf_definition["info"]["license"] = link["href"]
+            continue
 
 
-def map_version(wot_definition: Dict, sdf_definition: Dict):
+def map_version(wot_definition: Dict, sdf_definition: Dict, sdf_mapping_file: Dict):
     version_info = wot_definition.get("version", {})
     if "model" in version_info:
-        initialize_info_block(sdf_definition)
-        sdf_definition["info"]["version"] = version_info["model"]
+        for sdf_dict in [sdf_definition, sdf_mapping_file]:
+            pass
+            # initialize_info_block(sdf_dict)
+            # sdf_dict["info"]["version"] = version_info["model"]
 
 
-def map_context(wot_definition: Dict, sdf_definition: Dict):
+def map_context(wot_definition: Dict, sdf_definition: Dict, sdf_mapping_file):
     # TODO: How to deal with context elements without namespace?
     context = wot_definition["@context"]
     if isinstance(context, str):
@@ -343,7 +351,7 @@ def map_sdf_comment(wot_definition: Dict, sdf_definition: Dict):
         sdf_definition["$comment"] = wot_definition["sdf:$comment"]
 
 
-def convert_pointer(pointer) -> str:
+def convert_pointer(pointer: str, current_path: str) -> str:
     # TODO: Maybe this can be done more elegantly
     # TODO: Check if there are more possible mappings
     pointer = pointer.replace("events", "sdfEvent")
@@ -352,39 +360,315 @@ def convert_pointer(pointer) -> str:
     pointer = pointer.replace("schemaDefinitions", "sdfData")
     pointer = pointer.replace("input", "sdfInputData")
     pointer = pointer.replace("output", "sdfOutputData")
-    return pointer
+    return current_path + pointer[1:]
 
 
-def map_tm_ref(wot_model: Dict, wot_definition: Dict, sdf_definition: Dict):
+def map_tm_ref(
+    wot_model: Dict, wot_definition: Dict, sdf_definition: Dict, current_path: str
+):
     if "tm:ref" in wot_definition:
         pointer = wot_definition["tm:ref"]
-        resolved_definition = resolve_pointer(wot_model, pointer[1:])
-        if "sdf:jsonPointer" in resolved_definition:
-            sdf_definition["sdfRef"] = resolved_definition["sdf:jsonPointer"]
-        else:
-            sdf_definition["sdfRef"] = convert_pointer(pointer)
+        sdf_definition["sdfRef"] = convert_pointer(pointer, current_path)
 
 
-def convert_wot_tm_to_sdf(thing_model: Dict, placeholder_map=None) -> Dict:
+def map_tm_required(
+    wot_model: Dict, wot_definition: Dict, sdf_definition: Dict, current_path: str
+):
+    if "tm:required" in wot_definition:
+        pointers = wot_definition["tm:required"]
+        converted_pointers = [convert_pointer(x, current_path) for x in pointers]
+        sdf_definition["sdfRequired"] = converted_pointers
+
+
+def map_thing_model_to_sdf_object(
+    thing_model: Dict,
+    thing_model_key: str,
+    sdf_definition,
+    sdf_mapping_file,
+    current_path: str,
+    placeholder_map=None,
+):
+    sdf_object: Dict = {}
+
+    sdf_thing_key = thing_model.get("sdf:objectKey")
+    if sdf_thing_key is not None:
+        thing_model_key = sdf_thing_key
+    elif thing_model_key is None:
+        thing_model_key = f"sdfObject{len(sdf_definition)}"
+
+    sdf_object_path = f"{current_path}/sdfObject/{thing_model_key}"
+
+    map_thing_title(thing_model, sdf_object)
+    map_thing_description(thing_model, sdf_object)
+    map_links(thing_model, sdf_object, sdf_mapping_file)
+    map_version(thing_model, sdf_object, sdf_mapping_file)
+
+    map_sdf_comment(thing_model, sdf_object)
+    map_tm_required(thing_model, thing_model, sdf_object, sdf_object_path)
+
+    map_properties(thing_model, sdf_object, sdf_mapping_file, sdf_object_path)
+    map_actions(thing_model, sdf_object, sdf_mapping_file, sdf_object_path)
+    map_events(thing_model, sdf_object, sdf_mapping_file, sdf_object_path)
+    map_schema_definitions(thing_model, sdf_object, sdf_mapping_file, sdf_object_path)
+
+    sdf_definition[thing_model_key] = sdf_object
+
+
+def map_thing_model_to_sdf_thing(
+    thing_model: Dict,
+    sub_models: Dict,
+    thing_model_key: str,
+    sdf_definition,
+    sdf_mapping_file,
+    current_path,
+    placeholder_map=None,
+    thing_model_collection=None,
+):
+    # TODO: Map @context, titles, descriptions of submodels?
+    sdf_thing: Dict = {}
+
+    sdf_thing_key = thing_model.get("sdf:thingKey")
+    if sdf_thing_key is not None:
+        thing_model_key = sdf_thing_key
+    elif thing_model_key is None:
+        thing_model_key = f"sdfThing{len(sdf_definition)}"
+
+    sdf_thing_path = f"{current_path}/sdfThing/{thing_model_key}"
+
+    map_tm_required(thing_model, thing_model, sdf_thing, sdf_thing_path)
+
+    map_thing_title(thing_model, sdf_thing)
+    map_thing_description(thing_model, sdf_thing)
+    map_links(thing_model, sdf_thing, sdf_mapping_file)
+    map_version(thing_model, sdf_thing, sdf_mapping_file)
+
+    map_sdf_comment(thing_model, sdf_thing)
+
+    map_properties(thing_model, sdf_thing, sdf_mapping_file, sdf_thing_path)
+    map_actions(thing_model, sdf_thing, sdf_mapping_file, sdf_thing_path)
+    map_events(thing_model, sdf_thing, sdf_mapping_file, sdf_thing_path)
+    map_schema_definitions(thing_model, sdf_thing, sdf_mapping_file, sdf_thing_path)
+
+    sdf_definition[thing_model_key] = sdf_thing
+
+    for key, value in sub_models.items():
+        local_sub_models = resolve_sub_things(
+            value,
+            placeholder_map=placeholder_map,
+            thing_collection=thing_model_collection,
+        )
+        map_thing_model(
+            value,
+            local_sub_models,
+            key,
+            sdf_thing,
+            sdf_mapping_file,
+            sdf_thing_path,
+            placeholder_map=placeholder_map,
+            thing_model_collection=thing_model_collection,
+        )
+
+
+def map_thing_model(
+    thing_model: Dict,
+    sub_models: Dict,
+    thing_model_key,
+    sdf_model,
+    sdf_mapping_file,
+    current_path: str,
+    placeholder_map=None,
+    thing_model_collection=None,
+):
+    if len(sub_models) > 0 or "sdf:thingKey" in thing_model:
+        sdf_things = sdf_model.get("sdfThing")
+        if sdf_things is None:
+            sdf_things = {}
+            sdf_model["sdfThing"] = sdf_things
+        map_thing_model_to_sdf_thing(
+            thing_model,
+            sub_models,
+            thing_model_key,
+            sdf_things,
+            sdf_mapping_file,
+            current_path,
+            placeholder_map=placeholder_map,
+            thing_model_collection=thing_model_collection,
+        )
+    else:
+        sdf_objects = sdf_model.get("sdfObject")
+        if sdf_objects is None:
+            sdf_objects = {}
+            sdf_model["sdfObject"] = sdf_objects
+        map_thing_model_to_sdf_object(
+            thing_model,
+            thing_model_key,
+            sdf_objects,
+            sdf_mapping_file,
+            current_path,
+            placeholder_map=placeholder_map,
+        )
+
+
+def get_license_link(thing_model: Dict):
+    for link in thing_model.get("links", []):
+        if link.get("rel") == "license":
+            return link
+
+    return None
+
+
+def map_infoblock_fields(thing_model, sdf_model):
+    # TODO: How to deal with infoblock information in submodels?
+    infoblock = {}
+
+    if "sdf:copyright" in thing_model:
+        infoblock["copyright"] = thing_model["sdf:copyright"]
+
+    license_link = get_license_link(thing_model)
+    if license_link is not None:
+        infoblock["license"] = license_link["href"]
+    elif "sdf:license" in thing_model:
+        infoblock["license"] = thing_model["sdf:license"]
+
+    if "sdf:title" in thing_model:
+        infoblock["title"] = thing_model["sdf:title"]
+
+    if "model" in thing_model.get("version", {}):
+        infoblock["version"] = thing_model["version"]["model"]
+
+    if len(infoblock) > 0:
+        sdf_model["info"] = infoblock
+
+
+def _get_submodel_key_from_link(link: Dict) -> str:
+    key = link.get("instanceName")
+    if key is None:
+        href: str = link["href"]
+        if href.startswith("#/"):
+            href = href[1:]
+        # TODO: Check if the actual map key should be the path/
+        parsed_href = urllib.parse.urlparse(href)
+        key = parsed_href.path
+        key = os.path.split(key)[1]
+        for file_extension in ["jsonld", "json", "tm", "td"]:
+            key = key.replace(f".{file_extension}", "")
+    return key
+
+
+def resolve_sub_things(thing_model: Dict, thing_collection=None, placeholder_map=None):
+    sub_models: Dict = {}
+
+    for link in thing_model.get("links", []):
+        if link.get("rel") == "tm:submodel":
+            sub_model = wot_common.retrieve_thing_model(
+                link["href"], thing_collection=thing_collection
+            )
+            wot_common.replace_placeholders(sub_model, placeholder_map)
+            key = _get_submodel_key_from_link(link)
+            sub_models[key] = sub_model
+
+    return sub_models
+
+
+def convert_wot_tm_to_sdf(
+    thing_model: Dict,
+    thing_model_key=None,
+    placeholder_map=None,
+    thing_model_collection=None,
+    top_model_keys: Union[Set[str], None] = None,
+) -> Dict:
+    if thing_model_collection is None and "@context" not in thing_model:
+        return convert_wot_tm_collection_to_sdf(
+            thing_model,
+            top_model_keys=top_model_keys,
+        )
+
     # TODO: Unmapped fields: @type, id, titles, descriptions, created,
     #       modified, support, base, forms, security,
     #       securityDefinitions, profile, schemaDefinitions
     sdf_model: Dict = {}
+    # TODO: Pass mapping file to conversion functions
+    sdf_mapping_file: Dict = {}
 
     thing_model = wot_common.resolve_extension(
         thing_model, resolve_relative_pointers=False
     )
     thing_model = wot_common.replace_placeholders(thing_model, placeholder_map)
 
-    map_thing_title(thing_model, sdf_model)
-    map_thing_description(thing_model, sdf_model)
-    map_links(thing_model, sdf_model)
-    map_version(thing_model, sdf_model)
-    map_context(thing_model, sdf_model)
+    # TODO: @context of submoduls needs to be integrated as well
+    map_context(thing_model, sdf_model, sdf_mapping_file)
+    map_infoblock_fields(thing_model, sdf_model)
 
-    map_properties(thing_model, sdf_model)
-    map_actions(thing_model, sdf_model)
-    map_events(thing_model, sdf_model)
-    map_schema_definitions(thing_model, sdf_model)
+    # TODO: This distinction needs to be revisited
+    if top_model_keys is None or len(top_model_keys) == 0:
+        sub_models = resolve_sub_things(
+            thing_model,
+            thing_collection=thing_model_collection,
+            placeholder_map=placeholder_map,
+        )
+        map_thing_model(
+            thing_model,
+            sub_models,
+            thing_model_key,
+            sdf_model,
+            sdf_mapping_file,
+            "#",
+            placeholder_map=placeholder_map,
+            thing_model_collection=thing_model_collection,
+        )
+    else:
+        top_level_models = [thing_model_collection[x] for x in top_model_keys]
+
+        for model, key in zip(top_level_models, top_model_keys):
+            sub_models = resolve_sub_things(
+                model,
+                thing_collection=thing_model_collection,
+                placeholder_map=placeholder_map,
+            )
+            map_thing_model(
+                model,
+                sub_models,
+                key,
+                sdf_model,
+                sdf_mapping_file,
+                "#",
+                placeholder_map=placeholder_map,
+                thing_model_collection=thing_model_collection,
+            )
+
+    # TODO: Schema needs to be updated.
+    try:
+        validate_sdf_model(sdf_model)
+    except jsonschema.exceptions.ValidationError:
+        warnings.warn(
+            "Conversion produced an invalid SDF model. "
+            "This might be the case because the SDF schema "
+            "has not been updated, yet."
+            "It is recommended that you check the result before using it."
+        )
 
     return sdf_model
+
+
+def convert_wot_tm_collection_to_sdf(
+    thing_model_collection: Dict,
+    root_model_key=None,
+    top_model_keys: Union[Set[str], None] = None,
+):
+    if root_model_key is not None:
+        root_model = thing_model_collection[root_model_key]
+    else:
+        # Use the first model in the map as default
+        root_model_key, root_model = list(thing_model_collection.items())[0]
+
+    if top_model_keys is None:
+        top_model_keys = set()
+
+    top_model_keys.add(root_model_key)
+
+    return convert_wot_tm_to_sdf(
+        root_model,
+        thing_model_key=root_model_key,
+        thing_model_collection=thing_model_collection,
+        top_model_keys=top_model_keys,
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     jsonschema
     jsonpointer
     json-merge-patch
+    validators
 
 [options.entry_points]
 console_scripts =

--- a/tests/converter/test_cli.py
+++ b/tests/converter/test_cli.py
@@ -170,11 +170,12 @@ def test_wot_td_tm_example_conversion():
 
 
 def test_sdf_json_conversion():
-    input = {}
+    input = {"sdfObject": {"Test": {}}}
 
     expected_result = {
         "@context": ["http://www.w3.org/ns/td", {"sdf": "https://example.com/sdf"}],
         "@type": "tm:ThingModel",
+        "sdf:objectKey": "Test",
     }
 
     result = json.loads(convert_sdf_to_wot_tm_from_json(json.dumps(input)))
@@ -188,7 +189,7 @@ def test_wot_json_conversion():
         "@type": "tm:ThingModel",
     }
 
-    expected_result = {}
+    expected_result = {"sdfObject": {"sdfObject0": {}}}
 
     result = json.loads(convert_wot_tm_to_sdf_from_json(json.dumps(input)))
 

--- a/tests/converter/test_wot_to_sdf.py
+++ b/tests/converter/test_wot_to_sdf.py
@@ -1,4 +1,5 @@
-from sdf_wot_converter import convert_wot_tm_to_sdf
+from sdf_wot_converter.converters.wot_to_sdf import convert_wot_tm_to_sdf
+from sdf_wot_converter.converters.wot_to_sdf import convert_wot_tm_collection_to_sdf
 
 
 def perform_conversion_test(input, expected_result):
@@ -14,7 +15,7 @@ def test_empty_tm_sdf_conversion():
         "@type": "tm:ThingModel",
     }
 
-    expected_result = {}
+    expected_result = {"sdfObject": {"sdfObject0": {}}}
 
     perform_conversion_test(input, expected_result)
 
@@ -42,25 +43,24 @@ def test_wot_tm_to_sdf_conversion():
     }
 
     expected_result = {
-        "info": {
-            "title": "Lamp Thing Model",
-            "copyright": "",
-            "license": "",
-            "version": "",
-        },
-        "sdfProperty": {
-            "status": {
-                "description": "current status of the lamp (on|off)",
-                "type": "string",
-                "writable": False,
-            }
-        },
-        "sdfAction": {"toggle": {"description": "Turn the lamp on or off"}},
-        "sdfEvent": {
-            "overheating": {
-                "description": "Lamp reaches a critical temperature (overheating)",
-                "sdfOutputData": {"type": "string"},
-            }
+        "sdfObject": {
+            "sdfObject0": {
+                "label": "Lamp Thing Model",
+                "sdfProperty": {
+                    "status": {
+                        "description": "current status of the lamp (on|off)",
+                        "type": "string",
+                        "writable": False,
+                    }
+                },
+                "sdfAction": {"toggle": {"description": "Turn the lamp on or off"}},
+                "sdfEvent": {
+                    "overheating": {
+                        "description": "Lamp reaches a critical temperature (overheating)",
+                        "sdfOutputData": {"type": "string"},
+                    }
+                },
+            },
         },
     }
 
@@ -83,6 +83,7 @@ def test_tm_sdf_namespace_conversion():
     expected_result = {
         "namespace": {"foo": "https://example.com/foo"},
         "defaultNamespace": "foo",
+        "sdfObject": {"sdfObject0": {}},
     }
 
     perform_conversion_test(input, expected_result)
@@ -103,7 +104,6 @@ def test_tm_sdf_property_conversion():
                 "multipleOf": 1,
                 "const": 5,
                 "default": 5,
-                "sdf:jsonPointer": "#/sdfProduct/blah/sdfThing/foo/sdfThing/bar/sdfObject/baz/sdfProperty/foo",
             },
             "bar": {
                 "type": "number",
@@ -121,63 +121,67 @@ def test_tm_sdf_property_conversion():
                 "maxLength": 5,
                 "pattern": "email",
             },
-            "foobar": {"type": "array", "minItems": 2, "maxItems": 5},
-            "barfoo": {"type": "object", "required": ["foo"]},
+            "foobar": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 5,
+                "items": {"type": "string"},
+            },
+            "barfoo": {
+                "type": "object",
+                "properties": {"foo": {"type": "string"}},
+                "required": ["foo"],
+            },
             "fizzbuzz": {},
         },
     }
 
     expected_result = {
-        "sdfProduct": {
-            "blah": {
-                "sdfThing": {
+        "sdfObject": {
+            "sdfObject0": {
+                "sdfProperty": {
                     "foo": {
-                        "sdfThing": {
-                            "bar": {
-                                "sdfObject": {
-                                    "baz": {
-                                        "sdfProperty": {
-                                            "foo": {
-                                                "type": "integer",
-                                                "minimum": 0,
-                                                "maximum": 9001,
-                                                "exclusiveMaximum": 9002,
-                                                "exclusiveMinimum": 1,
-                                                "multipleOf": 1,
-                                                "const": 5,
-                                                "default": 5,
-                                            },
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9001,
+                        "exclusiveMaximum": 9002,
+                        "exclusiveMinimum": 1,
+                        "multipleOf": 1,
+                        "const": 5,
+                        "default": 5,
+                    },
+                    "boo": {"type": "boolean", "const": True, "default": True},
+                    "bar": {
+                        "type": "number",
+                        "minimum": 0.0,
+                        "maximum": 9001.0,
+                        "exclusiveMaximum": 9002.0,
+                        "exclusiveMinimum": 1.0,
+                        "multipleOf": 1.0,
+                        "const": 5.0,
+                        "default": 5.0,
+                    },
+                    "baz": {
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 5,
+                        "pattern": "email",
+                    },
+                    "foobar": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 5,
+                        "items": {"type": "string"},
+                    },
+                    "barfoo": {
+                        "type": "object",
+                        "properties": {"foo": {"type": "string"}},
+                        "required": ["foo"],
+                    },
+                    "fizzbuzz": {},
+                },
             }
-        },
-        "sdfProperty": {
-            "boo": {"type": "boolean", "const": True, "default": True},
-            "bar": {
-                "type": "number",
-                "minimum": 0.0,
-                "maximum": 9001.0,
-                "exclusiveMaximum": 9002.0,
-                "exclusiveMinimum": 1.0,
-                "multipleOf": 1.0,
-                "const": 5.0,
-                "default": 5.0,
-            },
-            "baz": {
-                "type": "string",
-                "minLength": 3,
-                "maxLength": 5,
-                "pattern": "email",
-            },
-            "foobar": {"type": "array", "minItems": 2, "maxItems": 5},
-            "barfoo": {"type": "object", "required": ["foo"]},
-            "fizzbuzz": {},
-        },
+        }
     }
 
     perform_conversion_test(input, expected_result)
@@ -192,7 +196,7 @@ def test_tm_sdf_link_conversion():
         "links": [{"href": "https://example.org"}],
     }
 
-    expected_result = {}
+    expected_result = {"sdfObject": {"sdfObject0": {}}}
 
     perform_conversion_test(input, expected_result)
 
@@ -203,11 +207,21 @@ def test_tm_sdf_schema_definition_conversion():
     input = {
         "@context": ["http://www.w3.org/ns/td", {"sdf": "https://example.com/sdf"}],
         "@type": "tm:ThingModel",
-        "schemaDefinitions": {"foobar": {"type": "string"}},
+        "schemaDefinitions": {
+            "foobar": {"type": "string"},
+            "barfoo": {"type": "integer"},
+        },
     }
 
     expected_result = {
-        "sdfData": {"foobar": {"type": "string"}},
+        "sdfObject": {
+            "sdfObject0": {
+                "sdfData": {
+                    "foobar": {"type": "string"},
+                    "barfoo": {"type": "integer"},
+                }
+            }
+        }
     }
 
     perform_conversion_test(input, expected_result)
@@ -222,8 +236,166 @@ def test_tm_sdf_relative_tm_ref_conversion():
     }
 
     expected_result = {
-        "sdfData": {"foobar": {"type": "string"}},
-        "sdfAction": {"toggle": {"sdfInputData": {"sdfRef": "#/sdfData/foobar"}}},
+        "sdfObject": {
+            "sdfObject0": {
+                "sdfData": {"foobar": {"type": "string"}},
+                "sdfAction": {
+                    "toggle": {
+                        "sdfInputData": {
+                            "sdfRef": "#/sdfObject/sdfObject0/sdfData/foobar"
+                        }
+                    }
+                },
+            }
+        }
     }
 
     perform_conversion_test(input, expected_result)
+
+
+def test_tm_sdf_composited_conversion():
+    input = {
+        "@context": ["http://www.w3.org/ns/td", {"sdf": "https://example.com/sdf"}],
+        "@type": "tm:ThingModel",
+        "links": [
+            {
+                "href": "./examples/wot/example.tm.jsonld",
+                "rel": "tm:submodel",
+            }
+        ],
+    }
+
+    expected_result = {
+        "sdfThing": {
+            "sdfThing0": {
+                "sdfObject": {
+                    "example": {
+                        "label": "MyLampThing",
+                        "sdfAction": {"toggle": {}},
+                        "sdfEvent": {
+                            "overheating": {"sdfOutputData": {"type": "string"}}
+                        },
+                        "sdfProperty": {"status": {"type": "string"}},
+                    }
+                }
+            }
+        }
+    }
+
+    perform_conversion_test(input, expected_result)
+
+
+def test_tm_sdf_composited_conversion_with_affordance():
+    input = {
+        "@context": ["http://www.w3.org/ns/td", {"sdf": "https://example.com/sdf"}],
+        "@type": "tm:ThingModel",
+        "title": "Top Level Lamp Thing",
+        "links": [
+            {
+                "href": "./examples/wot/example.tm.jsonld",
+                "rel": "tm:submodel",
+                "instanceName": "smartlamp",
+            }
+        ],
+        "properties": {"status": {"type": "string"}},
+    }
+
+    expected_result = {
+        "sdfThing": {
+            "sdfThing0": {
+                "label": "Top Level Lamp Thing",
+                "sdfProperty": {"status": {"type": "string"}},
+                "sdfObject": {
+                    "smartlamp": {
+                        "label": "MyLampThing",
+                        "sdfAction": {"toggle": {}},
+                        "sdfEvent": {
+                            "overheating": {"sdfOutputData": {"type": "string"}}
+                        },
+                        "sdfProperty": {"status": {"type": "string"}},
+                    },
+                },
+            }
+        }
+    }
+
+    perform_conversion_test(input, expected_result)
+
+
+def test_tm_collection_sdf_conversion():
+    input = {
+        "baseModel": {
+            "@context": "https://www.w3.org/2022/wot/td/v1.1",
+            "@type": "tm:ThingModel",
+            "title": "Smart Ventilator Thing Model",
+            "links": [
+                {
+                    "rel": "tm:submodel",
+                    "href": "#/ventilation",
+                    "type": "application/tm+json",
+                    "instanceName": "ventilation",
+                },
+                {
+                    "rel": "tm:submodel",
+                    "href": "#/LED",
+                    "type": "application/tm+json",
+                    "instanceName": "led",
+                },
+            ],
+        },
+        "ventilation": {
+            "@context": "https://www.w3.org/2022/wot/td/v1.1",
+            "@type": "tm:ThingModel",
+            "title": "Ventilator Thing Model",
+            "links": [
+                {
+                    "rel": "tm:submodel",
+                    "href": "#/ventilationSubmodel",
+                    "type": "application/tm+json",
+                }
+            ],
+        },
+        "LED": {
+            "@context": "https://www.w3.org/2022/wot/td/v1.1",
+            "@type": "tm:ThingModel",
+            "title": "LED Thing Model",
+            "properties": {"status": {"type": "string"}},
+            "actions": {"toggle": {}},
+            "events": {"overheating": {"data": {"type": "string"}}},
+        },
+        "ventilationSubmodel": {
+            "@context": "https://www.w3.org/2022/wot/td/v1.1",
+            "@type": "tm:ThingModel",
+            "title": "Submodel of a Ventilator",
+        },
+    }
+
+    expected_result = {
+        "sdfThing": {
+            "baseModel": {
+                "label": "Smart Ventilator Thing Model",
+                "sdfObject": {
+                    "led": {
+                        "label": "LED Thing Model",
+                        "sdfAction": {"toggle": {}},
+                        "sdfEvent": {
+                            "overheating": {"sdfOutputData": {"type": "string"}}
+                        },
+                        "sdfProperty": {"status": {"type": "string"}},
+                    }
+                },
+                "sdfThing": {
+                    "ventilation": {
+                        "label": "Ventilator Thing Model",
+                        "sdfObject": {
+                            "ventilationSubmodel": {"label": "Submodel of a Ventilator"}
+                        },
+                    },
+                },
+            }
+        }
+    }
+
+    result = convert_wot_tm_collection_to_sdf(input)
+
+    assert result == expected_result


### PR DESCRIPTION
This PR applies a number of (breaking) changes to the project and completely redesigns the way conversions between SDF and WoT are handled.

In the new version, each sdfObject and sdfThing corresponds to exactly one TM/TD. In the case of nested TMs/TDs, parent TMs/TDs that also contain affordances are mapped to both an sdfThing and an sdfObject.

Furthermore, the structure of conversion functions will be simplified drastically in order to make the package more maintainable.

Edit: Now resolves #41 