### PR TITLE
Playground conversion fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,7 @@ test_output
 
 # Ignore vscode settings
 .vscode
+
+# Ignore playground conversion files
+output
+playground

--- a/sdf_wot_converter/__init__.py
+++ b/sdf_wot_converter/__init__.py
@@ -90,9 +90,11 @@ def convert_wot_td_to_tm(input: Dict):
     return td_to_tm.convert_td_to_tm(input)
 
 
-def convert_sdf_to_wot_tm_from_path(from_path: str, to_path: str, indent=4, **kwargs):
+def convert_sdf_to_wot_tm_from_path(
+    from_path: str, to_path: str, indent=4, origin_url=None
+):
     from_model = _load_model(from_path)
-    to_model = sdf_to_wot.convert_sdf_to_wot_tm(from_model)
+    to_model = sdf_to_wot.convert_sdf_to_wot_tm(from_model, origin_url=origin_url)
 
     _save_model(to_path, to_model, indent=indent)
 


### PR DESCRIPTION
#40 introduced a bug that lead to converted SDF models that don't include a link to the original model anymore. This PR fixes this issue. 

It also adds new playground conversion related entries to the .gitignore file.