### PR TITLE
chore(ci): replace Python 3.6 with Python 3.10

### DIFF
--- a/.github/workflows/build_status.yml
+++ b/.github/workflows/build_status.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages =
     sdf_wot_converter
     sdf_wot_converter.schemas
     sdf_wot_converter.converters
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     jsonschema
     jsonpointer


### PR DESCRIPTION
This PR removes python 3.6 (which is EOL by now) from the list of Python versions the CI runs against, and replaces it with Python 3.10, which is the latest version.