### PR TITLE
chore(setup.cfg): specify dependency versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,10 +23,10 @@ packages =
     sdf_wot_converter.cli
 python_requires = >=3.7
 install_requires =
-    jsonschema
-    jsonpointer
-    json-merge-patch
-    validators
+    jsonschema >=4.6.0, <5
+    jsonpointer >=2.3, <3
+    json-merge-patch >= 0.2.0, <1
+    validators >= 0.20.0, <1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Earlier, new versions of dependencies could cause the converter not to work anymore, as no indication of the required version numbers was given. This PR prevents that from happening again in the future, using semantic versioning.