### PR TITLE
fix: remove support for boolean exclusiveMinimum/exclusiveMaximum

### DIFF
--- a/sdf_wot_converter/converters/jsonschema.py
+++ b/sdf_wot_converter/converters/jsonschema.py
@@ -24,6 +24,8 @@ def map_common_json_schema_fields(
     map_max_items(source_definition, target_definition, mapped_fields)
     map_minimum(source_definition, target_definition, mapped_fields)
     map_maximum(source_definition, target_definition, mapped_fields)
+    map_exclusive_minimum(source_definition, target_definition, mapped_fields)
+    map_exclusive_maximum(source_definition, target_definition, mapped_fields)
     map_required(source_definition, target_definition, mapped_fields)
     map_format(source_definition, target_definition, mapped_fields)
     map_pattern(source_definition, target_definition, mapped_fields)
@@ -56,6 +58,28 @@ def map_maximum(source_definition, target_definition, mapped_fields: List[str]):
 def map_minimum(source_definition, target_definition, mapped_fields: List[str]):
     map_common_field(
         source_definition, target_definition, "minimum", mapped_fields=mapped_fields
+    )
+
+
+def map_exclusive_maximum(
+    source_definition, target_definition, mapped_fields: List[str]
+):
+    map_common_field(
+        source_definition,
+        target_definition,
+        "exclusiveMaximum",
+        mapped_fields=mapped_fields,
+    )
+
+
+def map_exclusive_minimum(
+    source_definition, target_definition, mapped_fields: List[str]
+):
+    map_common_field(
+        source_definition,
+        target_definition,
+        "exclusiveMinimum",
+        mapped_fields=mapped_fields,
     )
 
 

--- a/sdf_wot_converter/converters/sdf_to_tm.py
+++ b/sdf_wot_converter/converters/sdf_to_tm.py
@@ -309,8 +309,6 @@ def map_data_qualities(
         sdf_model, data_qualities, data_schema, suppress_roundtripping, mapped_fields
     )
     map_content_format(data_qualities, data_schema, mapped_fields)
-    _map_exclusive_maximum(data_qualities, data_schema, mapped_fields)
-    _map_exclusive_minimum(data_qualities, data_schema, mapped_fields)
 
     map_items(
         sdf_model, data_qualities, data_schema, suppress_roundtripping, mapped_fields
@@ -326,54 +324,6 @@ def map_data_qualities(
         map_readable(data_qualities, data_schema, mapped_fields)
 
     map_additional_fields(data_schema, data_qualities, mapped_fields)
-
-
-def _map_exclusive_min_max(
-    source_definition,
-    target_definition,
-    key: str,
-    exclusiveKey: str,
-    mapped_fields: List[str],
-):
-    exclusive_min_max = source_definition.get(exclusiveKey)
-
-    if exclusive_min_max is None:
-        return
-
-    mapped_fields.append(exclusiveKey)
-
-    if isinstance(exclusive_min_max, bool):
-        target_min_max = target_definition.get(key)
-
-        if exclusive_min_max:
-            target_definition[exclusiveKey] = target_min_max
-            del target_definition[key]
-    else:
-        target_definition[exclusiveKey] = exclusive_min_max
-
-
-def _map_exclusive_maximum(
-    source_definition, target_definition, mapped_fields: List[str]
-):
-    _map_exclusive_min_max(
-        source_definition,
-        target_definition,
-        "maximum",
-        "exclusiveMaximum",
-        mapped_fields,
-    )
-
-
-def _map_exclusive_minimum(
-    source_definition, target_definition, mapped_fields: List[str]
-):
-    _map_exclusive_min_max(
-        source_definition,
-        target_definition,
-        "minimum",
-        "exclusiveMinimum",
-        mapped_fields,
-    )
 
 
 def map_writable(sdf_property, wot_property, mapped_fields):

--- a/sdf_wot_converter/converters/tm_to_sdf.py
+++ b/sdf_wot_converter/converters/tm_to_sdf.py
@@ -270,8 +270,6 @@ def map_data_schema_fields(
     map_content_format(wot_definition, sdf_definition, mapped_fields)
     map_nullable(wot_definition, sdf_definition, mapped_fields)
     map_sdf_type(wot_definition, sdf_definition, mapped_fields)
-    _map_exclusive_maximum(wot_definition, sdf_definition, mapped_fields)
-    _map_exclusive_minimum(wot_definition, sdf_definition, mapped_fields)
 
     map_items(
         thing_model,
@@ -294,28 +292,6 @@ def map_data_schema_fields(
 
     map_additional_fields(
         sdf_mapping_file, wot_definition, mapping_file_path, mapped_fields
-    )
-
-
-def _map_exclusive_maximum(
-    source_definition, target_definition, mapped_fields: List[str]
-):
-    map_common_field(
-        source_definition,
-        target_definition,
-        "exclusiveMaximum",
-        mapped_fields=mapped_fields,
-    )
-
-
-def _map_exclusive_minimum(
-    source_definition, target_definition, mapped_fields: List[str]
-):
-    map_common_field(
-        source_definition,
-        target_definition,
-        "exclusiveMinimum",
-        mapped_fields=mapped_fields,
     )
 
 

--- a/tests/test_sdf_to_tm.py
+++ b/tests/test_sdf_to_tm.py
@@ -400,52 +400,6 @@ def test_sdf_tm_type_conversion():
     perform_sdf_roundtrip_test(input)
 
 
-def test_sdf_tm_exclusive_min_max_boolean_conversion():
-    input = {
-        "sdfObject": {
-            "Test": {
-                "sdfProperty": {
-                    "bar": {
-                        "minimum": 0.0,
-                        "maximum": 9002.0,
-                        "exclusiveMinimum": True,
-                        "exclusiveMaximum": True,
-                    },
-                    "baz": {
-                        "minimum": 0.0,
-                        "maximum": 9002.0,
-                        "exclusiveMinimum": False,
-                        "exclusiveMaximum": False,
-                    },
-                },
-            }
-        }
-    }
-
-    expected_result = {
-        "@context": [
-            "https://www.w3.org/2022/wot/td/v1.1",
-            {"sdf": "https://example.com/sdf"},
-        ],
-        "@type": "tm:ThingModel",
-        "properties": {
-            "bar": {
-                "exclusiveMinimum": 0.0,
-                "exclusiveMaximum": 9002.0,
-                "observable": True,
-            },
-            "baz": {
-                "minimum": 0.0,
-                "maximum": 9002.0,
-                "observable": True,
-            },
-        },
-        "sdf:objectKey": "Test",
-    }
-
-    perform_conversion_test(input, expected_result)
-
-
 def test_sdf_tm_action_conversion():
     input = {
         "sdfObject": {


### PR DESCRIPTION
Since `exclusiveMinimum` and `exclusiveMaximum` are not actually allowed to have a boolean value in SDF anymore (also see https://github.com/ietf-wg-asdf/SDF/pull/86), this PR adjusts the logic for mapping the field between WoT and SDF accordingly, turning it into a simple copy operation. 

Once https://github.com/ietf-wg-asdf/SDF/pull/86 should be merged, the validation schemas also need to be updated.