### PR TITLE
feat: update mapping between sdfRequired and tm:optional

### DIFF
--- a/tests/test_sdf_to_tm.py
+++ b/tests/test_sdf_to_tm.py
@@ -130,6 +130,12 @@ def test_sdf_tm_example_conversion():
             }
         },
         "sdf:objectKey": "Switch",
+        "tm:optional": [
+            "/actions/off",
+            "/actions/on",
+            "/actions/toggle",
+            "/properties/value",
+        ],
     }
 
     perform_conversion_test(input, expected_result)
@@ -408,6 +414,13 @@ def test_sdf_tm_type_conversion():
             },
         },
         "sdf:objectKey": "Test",
+        "tm:optional": [
+            "/properties/bar",
+            "/properties/barfoo",
+            "/properties/baz",
+            "/properties/foo",
+            "/properties/foobar",
+        ],
     }
 
     perform_conversion_test(input, expected_result)
@@ -440,6 +453,9 @@ def test_sdf_tm_action_conversion():
             }
         },
         "sdf:objectKey": "Test",
+        "tm:optional": [
+            "/actions/foobar",
+        ],
     }
 
     perform_conversion_test(input, expected_result)
@@ -471,6 +487,10 @@ def test_sdf_tm_event_conversion():
             "foobaz": {},
         },
         "sdf:objectKey": "Test",
+        "tm:optional": [
+            "/events/foobar",
+            "/events/foobaz",
+        ],
     }
 
     perform_conversion_test(input, expected_result)
@@ -536,6 +556,14 @@ def test_sdf_tm_sdf_ref_conversion():
             },
         },
         "sdf:objectKey": "Test",
+        "tm:optional": [
+            "/actions/foobar",
+            "/actions/foobaz",
+            "/events/foobar",
+            "/events/foobaz",
+            "/properties/foobar",
+            "/properties/foobaz",
+        ],
     }
 
     perform_conversion_test(input, expected_result)
@@ -566,11 +594,11 @@ def test_sdf_tm_nested_model():
                                         },
                                         "sdfRequired": [
                                             "#/sdfThing/blah/sdfThing/foo/sdfThing/bar/"
-                                            "sdfObject/baz/sdfProperty/foobar",
-                                            "#/sdfThing/blah/sdfThing/foo/sdfThing/bar/"
                                             "sdfObject/baz/sdfAction/foobar",
                                             "#/sdfThing/blah/sdfThing/foo/sdfThing/bar/"
                                             "sdfObject/baz/sdfEvent/foobar",
+                                            "#/sdfThing/blah/sdfThing/foo/sdfThing/bar/"
+                                            "sdfObject/baz/sdfProperty/foobar",
                                         ],
                                     }
                                 }
@@ -630,11 +658,6 @@ def test_sdf_tm_nested_model():
             ],
             "@type": "tm:ThingModel",
             "sdf:objectKey": "baz",
-            "tm:required": [
-                "/properties/foobar",
-                "/actions/foobar",
-                "/events/foobar",
-            ],
             "actions": {"foobar": {"title": "hi"}},
             "properties": {"foobar": {"title": "hi", "observable": True}},
             "events": {"foobar": {"title": "hi"}},
@@ -747,6 +770,9 @@ def test_sdf_tm_succeeding_URL_sdf_ref():
             },
         },
         "sdf:objectKey": "Test",
+        "tm:optional": [
+            "/properties/foo",
+        ],
     }
 
     perform_conversion_test(input, expected_result)
@@ -783,6 +809,7 @@ def test_sdf_tm_sdf_choice():
             },
         },
         "sdf:objectKey": "Test",
+        "tm:optional": ["/properties/foobar"],
     }
 
     perform_conversion_test(input, expected_result)
@@ -904,6 +931,12 @@ def test_sdf_tm_sdf_data_conversion():
                 },
             },
         },
+        "tm:optional": [
+            "/actions/foobar",
+            "/actions/foobaz",
+            "/events/foobar",
+            "/events/foobaz",
+        ],
     }
 
     perform_conversion_test(input, expected_result)
@@ -980,7 +1013,12 @@ def test_sdf_tm_nested_sdf_conversion():
             ],
             "@type": "tm:ThingModel",
             "sdf:thingKey": "foo",
-            "properties": {"status": {"observable": True}},
+            "properties": {
+                "status": {
+                    "observable": True,
+                }
+            },
+            "tm:optional": ["/properties/status"],
             "links": [
                 {"href": "#/sdfThing~1foo~1sdfObject~1bar", "rel": "tm:submodel"}
             ],
@@ -993,6 +1031,7 @@ def test_sdf_tm_nested_sdf_conversion():
             "@type": "tm:ThingModel",
             "sdf:objectKey": "bar",
             "actions": {"toggle": {}},
+            "tm:optional": ["/actions/toggle"],
         },
     }
 
@@ -1035,11 +1074,13 @@ def test_sdf_tm_suppress_roundtripping_fields():
             "links": [
                 {"href": "#/sdfThing~1foo~1sdfObject~1bar", "rel": "tm:submodel"}
             ],
+            "tm:optional": ["/properties/status"],
         },
         "sdfThing/foo/sdfObject/bar": {
             "@context": ["https://www.w3.org/2022/wot/td/v1.1"],
             "@type": "tm:ThingModel",
             "actions": {"toggle": {}},
+            "tm:optional": ["/actions/toggle"],
         },
     }
 
@@ -1179,6 +1220,12 @@ def test_sdf_tm_duplicate_keys():
                     "observable": True,
                 }
             },
+            "tm:optional": [
+                "/actions/off",
+                "/actions/on",
+                "/actions/toggle",
+                "/properties/value",
+            ],
         },
     }
 

--- a/tests/test_tm_to_sdf.py
+++ b/tests/test_tm_to_sdf.py
@@ -88,6 +88,11 @@ def test_wot_tm_to_sdf_conversion():
                             "writable": False,
                         }
                     },
+                    "sdfRequired": [
+                        "#/sdfObject/sdfObject0/sdfAction/toggle",
+                        "#/sdfObject/sdfObject0/sdfEvent/overheating",
+                        "#/sdfObject/sdfObject0/sdfProperty/status",
+                    ],
                 }
             },
         },
@@ -244,7 +249,16 @@ def test_tm_sdf_property_conversion():
                             "observable": False,
                             "type": "array",
                         },
-                    }
+                    },
+                    "sdfRequired": [
+                        "#/sdfObject/sdfObject0/sdfProperty/bar",
+                        "#/sdfObject/sdfObject0/sdfProperty/barfoo",
+                        "#/sdfObject/sdfObject0/sdfProperty/baz",
+                        "#/sdfObject/sdfObject0/sdfProperty/boo",
+                        "#/sdfObject/sdfObject0/sdfProperty/fizzbuzz",
+                        "#/sdfObject/sdfObject0/sdfProperty/foo",
+                        "#/sdfObject/sdfObject0/sdfProperty/foobar",
+                    ],
                 }
             }
         },
@@ -361,6 +375,11 @@ def test_tm_sdf_relative_tm_ref_conversion():
                         "sdfRef": "#/sdfObject/sdfObject0/sdfProperty/status1",
                     },
                 },
+                "sdfRequired": [
+                    "#/sdfObject/sdfObject0/sdfAction/toggle",
+                    "#/sdfObject/sdfObject0/sdfProperty/status1",
+                    "#/sdfObject/sdfObject0/sdfProperty/status2",
+                ],
                 "sdfData": {"foobar": {"type": "string"}},
             }
         },
@@ -412,6 +431,12 @@ def test_tm_sdf_composited_conversion():
                         "sdfProperty": {
                             "status": {"observable": False, "type": "string"}
                         },
+                        "sdfRequired": [
+                            "#/sdfThing/sdfThing0/sdfObject/example/sdfAction/toggle",
+                            "#/sdfThing/sdfThing0/sdfObject/example/sdfEvent/"
+                            "overheating",
+                            "#/sdfThing/sdfThing0/sdfObject/example/sdfProperty/status",
+                        ],
                     }
                 }
             }
@@ -469,6 +494,9 @@ def test_tm_sdf_composited_conversion_with_affordance():
             "sdfThing0": {
                 "label": "Top Level Lamp Thing",
                 "sdfProperty": {"status": {"type": "string", "observable": False}},
+                "sdfRequired": [
+                    "#/sdfThing/sdfThing0/sdfProperty/status",
+                ],
                 "sdfObject": {
                     "smartlamp": {
                         "label": "MyLampThing",
@@ -479,6 +507,13 @@ def test_tm_sdf_composited_conversion_with_affordance():
                         "sdfProperty": {
                             "status": {"type": "string", "observable": False}
                         },
+                        "sdfRequired": [
+                            "#/sdfThing/sdfThing0/sdfObject/smartlamp/sdfAction/toggle",
+                            "#/sdfThing/sdfThing0/sdfObject/smartlamp/sdfEvent/"
+                            "overheating",
+                            "#/sdfThing/sdfThing0/sdfObject/smartlamp/sdfProperty/"
+                            "status",
+                        ],
                     },
                 },
             }
@@ -574,6 +609,11 @@ def test_tm_collection_sdf_conversion():
                         "sdfProperty": {
                             "status": {"type": "string", "observable": False}
                         },
+                        "sdfRequired": [
+                            "#/sdfThing/baseModel/sdfObject/led/sdfAction/toggle",
+                            "#/sdfThing/baseModel/sdfObject/led/sdfEvent/overheating",
+                            "#/sdfThing/baseModel/sdfObject/led/sdfProperty/status",
+                        ],
                     }
                 },
                 "sdfThing": {

--- a/tests/test_tm_to_td.py
+++ b/tests/test_tm_to_td.py
@@ -348,7 +348,7 @@ def test_tm_td_tm_ref():
     perform_conversion_test(input, expected_result)
 
 
-def test_tm_td_tm_required():
+def test_tm_td_tm_optional():
     input = {
         "@context": ["https://www.w3.org/2022/wot/td/v1.1"],
         "@type": "tm:ThingModel",
@@ -361,7 +361,7 @@ def test_tm_td_tm_required():
                 "forms": [{"href": "https://mylamp.example.com/status"}],
             }
         },
-        "tm:required": ["#/properties/status"],
+        "tm:optional": ["#/properties/status"],
     }
 
     expected_result = {
@@ -647,7 +647,7 @@ def test_tm_td_with_nesting():
     perform_conversion_test(input, expected_result)
 
 
-def test_tm_td_tm_required_removal():
+def test_tm_td_tm_optional_removal():
     input = {
         "@context": ["https://www.w3.org/2022/wot/td/v1.1"],
         "@type": "tm:ThingModel",
@@ -661,7 +661,7 @@ def test_tm_td_tm_required_removal():
             },
             "removedStatus": {"type": "string"},
         },
-        "tm:required": ["#/properties/status"],
+        "tm:optional": ["/properties/removedStatus"],
     }
 
     expected_result = {


### PR DESCRIPTION
This PR aligns the implementation with the latest TD specification version, where `tm:required` has been replaced with `tm:optional`. In a follow-up PR, some additional refactoring/cleanup should be applied.